### PR TITLE
Fix assistant reply None

### DIFF
--- a/appp.py
+++ b/appp.py
@@ -255,9 +255,9 @@ if user_input:
             st.session_state.messages + [assistant_call_msg] + tool_messages,
             None, "", top_k=0,
         )
-        assistant_reply = follow_resp.choices[0].message.content
+        assistant_reply = follow_resp.choices[0].message.content or ""
     else:
-        assistant_reply = choice.message.content
+        assistant_reply = choice.message.content or ""
 
     st.chat_message("assistant").markdown(assistant_reply)
     st.session_state.messages.append(


### PR DESCRIPTION
## Summary
- avoid storing None `assistant_reply` values in the chat session

## Testing
- `python -m py_compile appp.py features/llm/chat.py features/llm/tools.py features/llm/prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb3697b348324a4a19513f1f1d531