### PR TITLE
Fix drawdown calculation for percent returns

### DIFF
--- a/features/analytics/portfolio.py
+++ b/features/analytics/portfolio.py
@@ -127,7 +127,10 @@ def compute_portfolio_metrics(
 
     annualized_volatility = returns_series.std(ddof=0) * math.sqrt(periods_per_year)
 
-    mdd = max_drawdown(series, is_prices=is_prices)
+    if is_prices:
+        mdd = max_drawdown(series, is_prices=True)
+    else:
+        mdd = max_drawdown(returns_series, is_prices=False)
 
     return {
         "cumulative_return": cumulative_return,


### PR DESCRIPTION
## Summary
- fix max drawdown when returns are given in percentages by using the converted returns series

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840044e1ed083248256100de7ecfcf5