### PR TITLE
Add FX rate tool

### DIFF
--- a/appp.py
+++ b/appp.py
@@ -19,7 +19,11 @@ from features.analytics.portfolio import (
     yearly_performance,
     max_drawdown,
 )
-from features.marketdata.yahoo import get_stock_quote, get_stock_history
+from features.marketdata.yahoo import (
+    get_stock_quote,
+    get_stock_history,
+    get_fx_rate,
+)
 from features.excel.loader import load_excel
 
 # --------------------------------------------------------------------------- #
@@ -164,6 +168,14 @@ if user_input:
                     f"Trailing P/E: {q['pe'] or 'N/A'}"
                 )
                 tool_content = json.dumps(q)
+
+            # ---------- fx rate ------------------------------------------- #
+            elif name == "get_fx_rate":
+                fx = get_fx_rate(args["pair"])
+                st.markdown(
+                    f"**{fx['pair']}** {fx['rate']:.4f} ({fx['changePct']:+.2f}%)"
+                )
+                tool_content = json.dumps(fx)
 
             # ---------- price history ------------------------------------- #
             elif name == "get_stock_history":

--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -117,6 +117,21 @@ HISTORY_TOOL_SCHEMA = {
     },
 }
 
+FX_RATE_TOOL_SCHEMA = {
+    "name": "get_fx_rate",
+    "description": "Return the latest FX spot rate for a currency pair like 'USD/SGD'.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "pair": {
+                "type": "string",
+                "description": "Currency pair, e.g. 'USD/SGD'.",
+            }
+        },
+        "required": ["pair"],
+    },
+}
+
 DRAWDOWN_TOOL_SCHEMA = {
     "name": "calculate_max_drawdown",
     "description": (
@@ -143,5 +158,6 @@ TOOLS = [
     {"type": "function", "function": YEARLY_TOOL_SCHEMA},
     {"type": "function", "function": QUOTE_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": HISTORY_TOOL_SCHEMA},
+    {"type": "function", "function": FX_RATE_TOOL_SCHEMA},
     {"type": "function", "function": DRAWDOWN_TOOL_SCHEMA},  # ← NEW
 ]

--- a/features/marketdata/yahoo.py
+++ b/features/marketdata/yahoo.py
@@ -151,3 +151,21 @@ def get_stock_quote(ticker: str) -> Dict:
         "pe": info.get("trailing_pe"),
         "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
     }
+
+
+def get_fx_rate(pair: str) -> Dict:
+    """Return the latest FX spot rate for ``pair`` like ``USD/SGD``."""
+    sym = pair.replace("/", "").upper()
+    T = yf.Ticker(f"{sym}=X")
+    info = T.fast_info
+
+    price = float(info["last_price"])
+    prev_close = float(info["previous_close"])
+    pct = (price / prev_close - 1) * 100 if prev_close else None
+
+    return {
+        "pair": pair.upper().replace("/", "/"),
+        "rate": price,
+        "changePct": pct,
+        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+    }


### PR DESCRIPTION
## Summary
- provide helper to fetch FX spot quotes via Yahoo Finance
- expose FX rate function to the LLM tools
- handle `get_fx_rate` tool calls in the Streamlit app

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^\.venv/')`

------
https://chatgpt.com/codex/tasks/task_e_684100758d288324affccbe8bead34cc