### PR TITLE
Fix max_drawdown ambiguity with pandas Series

### DIFF
--- a/features/analytics/portfolio.py
+++ b/features/analytics/portfolio.py
@@ -60,16 +60,18 @@ def _ensure_returns(
 
 
 def max_drawdown(series: Sequence[float | int], *, is_prices: bool = True) -> float:
-    """
-    Return the maximum peak-to-trough draw-down as a **negative decimal**.
+    """Return the maximum peak-to-trough draw-down as a **negative decimal**.
 
     If *is_prices* is False, the numbers are interpreted as arithmetic returns
     and converted to an equity curve before the draw-down calculation.
     """
-    if not series:
+    if series is None:
         return float("nan")
 
     prices = np.asarray(series, dtype="float64")
+
+    if prices.size == 0:
+        return float("nan")
 
     if not is_prices:
         prices = np.cumprod(1.0 + prices)  # build price curve from returns


### PR DESCRIPTION
## Summary
- prevent ambiguous truth evaluation in `max_drawdown`
- return NaN when the passed series is `None` or empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e23c688832491c5988e1cac1494