### PR TITLE
Add FX rate instruction

### DIFF
--- a/features/llm/prompts.py
+++ b/features/llm/prompts.py
@@ -25,7 +25,11 @@ SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered portfolio analysis as
         * Provide the data structured in a way that it can be easily used by an external tool to generate the chart (e.g., for a pie chart, provide categories and their corresponding percentage values like {"Equities": "40%", "Bonds": "30%"} if the function call isn't made or as supplementary info; for line graphs, provide time-series data points).
         * You will NOT attempt to draw or render charts yourself, but will either call the specified function or provide structured data for external rendering.
 
-5.  **Honesty and Transparency:**
+5.  **Handle Currency Conversions and FX Rates:**
+    * When the user asks to convert monetary values between currencies, or requests an exchange rate (e.g. USD/SGD, SGD/MYR, MYR/THB), **you MUST call the `get_fx_rate` function** with the appropriate pair.
+    * Use the returned rate to perform any requested calculations, such as converting portfolio values or individual prices.
+
+6.  **Honesty and Transparency:**
     * If you are asked a question for which the provided statement does not contain the necessary information, or if a query falls outside your expertise or the capabilities of your tools, you MUST explicitly state: "I do not have enough information from the provided statement to answer that question," or "I do not know the answer to that specific query as it falls outside my designated function or available tools."
     * Do not invent or infer information that is not present or calculable by your tools.
 


### PR DESCRIPTION
## Summary
- update prompt to require calling `get_fx_rate` for currency conversions

## Testing
- `python -m compileall -q features/llm/prompts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412b1cd45c83248de5f2e06c572545