### PR TITLE
Improve formula formatting instructions

### DIFF
--- a/features/llm/prompts.py
+++ b/features/llm/prompts.py
@@ -53,6 +53,7 @@ SYSTEM_PROMPT_CORE = SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered 
 * Organize complex information logically, using bullet points or numbered lists where appropriate for readability.
 * Be objective and data-driven in your analysis and recommendations.
 * Ensure all financial terminology is used correctly.
+* When explaining formulas, present them in simple plain text (e.g., `(a/b) * 100`) rather than raw LaTeX code.
 
 **Crucial Limitations & Disclaimers:**
 * You do not have access to real-time market data except through the provided Yahoo Finance tools.


### PR DESCRIPTION
## Summary
- instruct the system prompt to keep formulas in plain text

## Testing
- `ruff check .` *(fails: F401 import unused in `appp.py`)*

------
https://chatgpt.com/codex/tasks/task_e_684284c77d808324823e85df8b5e6ec3