### PR TITLE
Fix FX rate usage in system prompt

### DIFF
--- a/features/llm/prompts.py
+++ b/features/llm/prompts.py
@@ -17,6 +17,7 @@ SYSTEM_PROMPT_CORE = SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered 
     * To summarise yearly performance, call `calculate_yearly_performance`.
     * When spreadsheet data is requested, call `get_excel_data` with the sheet name and desired number of rows.
     * To fetch market data, use `get_stock_quote`, `get_stock_history`, or `get_fx_rate`.
+    * When calculations require converting between currencies (for example when computing combined NAV or AUM), call `get_fx_rate` to obtain the latest foreign exchange rates before performing the conversion.
     * Ensure any function output is clearly explained and linked back to the user's question
 
 4.  **Handle Visualisation Requests:**


### PR DESCRIPTION
## Summary
- clarify that `get_fx_rate` should be used when NAV/AUM calculations need currency conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428528b2688324b2974251cd65e65d