### PR TITLE
Fix duplicate default in HISTORY_TOOL_SCHEMA

### DIFF
--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -93,7 +93,6 @@ HISTORY_TOOL_SCHEMA = {
                     "ytd",
                     "max",
                 ],
-                "default": "1y",
                 "default": "1y"
             },
             "interval": {


### PR DESCRIPTION
## Summary
- remove redundant default entry from `HISTORY_TOOL_SCHEMA`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467862c0e0832490b8b71ece9c397d