### PR TITLE
Fix annualized return computation

### DIFF
--- a/appp.py
+++ b/appp.py
@@ -191,10 +191,10 @@ if user_input:
                     if sheet not in excel_data:
                         sheet = next(iter(excel_data))
                     df = excel_data[sheet]
-                    is_prices = args.get("is_prices", True)
+                    is_prices = args.get("is_prices", False)
                     returns_are_percent = args.get("returns_are_percent", False)
                     try:
-                        ppy = args.get("periods_per_year")
+                        ppy = args.get("periods_per_year", 12)
                         dates = pd.to_datetime(df.iloc[:, 0], errors="coerce")
                         values = pd.to_numeric(df.iloc[:, 1], errors="coerce")
                         mask = dates.notna() & values.notna()
@@ -404,7 +404,7 @@ if user_input:
                     fund_name = args.get("fund_name")
                     sheet = args.get("sheet", "Main Funds")
                     is_prices = args.get("is_prices", False)
-                    returns_are_percent = args.get("returns_are_percent", True)
+                    returns_are_percent = args.get("returns_are_percent", False)
                     
                     # Try multiple sheet names if the specified one doesn't exist
                     sheets_to_try = [sheet] if sheet in excel_data else []

--- a/features/analytics/portfolio.py
+++ b/features/analytics/portfolio.py
@@ -51,7 +51,6 @@ def _ensure_returns(
 
     if returns_are_percent:
         returns = returns / 100.0
-    print("printing out _ensure_returns: ", returns)
     return returns.dropna()
 
 
@@ -154,9 +153,8 @@ def compute_portfolio_metrics(
     cumulative_return = (1.0 + returns_series).prod() - 1.0
 
     n_periods = len(returns_series)
-    annualized_return = (1.0 + cumulative_return) ** (
-        periods_per_year / n_periods
-    ) - 1.0
+    geometric_mean = (1.0 + cumulative_return) ** (1.0 / n_periods) - 1.0
+    annualized_return = (1.0 + geometric_mean) ** periods_per_year - 1.0
 
     annualized_volatility = returns_series.std(ddof=0) * math.sqrt(periods_per_year)
 
@@ -177,12 +175,15 @@ def compute_portfolio_metrics_from_excel(
     file: str | bytes,
     *,
     sheet: str | int | None = 0,
-    is_prices: bool = True,
-    periods_per_year: int | None = None,
+    is_prices: bool = False,
+    periods_per_year: int | None = 12,
     risk_free_rate: float = 0.0,
     returns_are_percent: bool | None = False,
 ) -> Mapping[str, float]:
-    """Read an Excel sheet (first column dates, second values) and compute metrics."""
+    """Read an Excel sheet (first column dates, second values) and compute metrics.
+
+    By default the values are treated as **monthly returns in decimal form**.
+    """
     df = pd.read_excel(file, sheet_name=sheet)
     if df.shape[1] < 2:
         raise ValueError("Excel sheet must have at least two columns")

--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -213,9 +213,9 @@ FUND_METRICS_TOOL_SCHEMA = {
                 "default": False
             },
             "returns_are_percent": {
-                "type": "boolean", 
+                "type": "boolean",
                 "description": "Whether return values are in percentage form",
-                "default": True
+                "default": False
             }
         },
         "required": ["fund_name"],
@@ -232,8 +232,8 @@ PORTFOLIO_EXCEL_TOOL_SCHEMA = {
         "type": "object",
         "properties": {
             "sheet": {"type": "string"},
-            "is_prices": {"type": "boolean", "default": True},
-            "periods_per_year": {"type": "integer"},
+            "is_prices": {"type": "boolean", "default": False},
+            "periods_per_year": {"type": "integer", "default": 12},
             "returns_are_percent": {"type": "boolean", "default": False},
         },
         "required": ["sheet"],

--- a/revised_scripts_with_error_handling/appp.py
+++ b/revised_scripts_with_error_handling/appp.py
@@ -362,7 +362,7 @@ if user_input:
                     fund_name = args.get("fund_name")
                     sheet = args.get("sheet", "Main Funds")
                     is_prices = args.get("is_prices", False)
-                    returns_are_percent = args.get("returns_are_percent", True)
+                    returns_are_percent = args.get("returns_are_percent", False)
                     
                     # Try multiple sheet names if the specified one doesn't exist
                     sheets_to_try = [sheet] if sheet in excel_data else []

--- a/revised_scripts_with_error_handling/llm/tools.py
+++ b/revised_scripts_with_error_handling/llm/tools.py
@@ -213,9 +213,9 @@ FUND_METRICS_TOOL_SCHEMA = {
                 "default": False
             },
             "returns_are_percent": {
-                "type": "boolean", 
+                "type": "boolean",
                 "description": "Whether return values are in percentage form",
-                "default": True
+                "default": False
             }
         },
         "required": ["fund_name"],


### PR DESCRIPTION
## Summary
- clarify annualized return calculation
- remove debug output
- default to monthly return decimals when loading Excel data

## Testing
- `python -m py_compile features/analytics/portfolio.py features/llm/tools.py appp.py revised_scripts_with_error_handling/appp.py revised_scripts_with_error_handling/llm/tools.py`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bdad9ad288324bab179b4785e5df0