### PR TITLE
Enable lookup of monthly fund values

### DIFF
--- a/appp.py
+++ b/appp.py
@@ -26,7 +26,11 @@ from features.marketdata.yahoo import (
     get_stock_history,
     get_fx_rate,
 )
-from features.excel.loader import load_excel, get_fund_series
+from features.excel.loader import (
+    load_excel,
+    get_fund_series,
+    get_fund_month_value,
+)
 
 # --------------------------------------------------------------------------- #
 # Streamlit page config                                                       #
@@ -394,6 +398,33 @@ if user_input:
                         except Exception as exc:
                             tool_content = f"Error retrieving fund series for '{fund_name}': {exc}"
                             st.error(f"Error retrieving fund data: {exc}")
+
+            # ---------- fund value for specific month -------------------- #
+            elif name == "get_fund_month_value":
+                excel_data = st.session_state.get("excel_data")
+                if not excel_data:
+                    tool_content = "No Excel data available. Please upload an Excel file first."
+                else:
+                    sheet = args.get("sheet")
+                    fund_name = args.get("fund_name")
+                    month = args.get("month")
+                    if sheet not in excel_data:
+                        available_sheets = list(excel_data.keys())
+                        tool_content = (
+                            f"Sheet '{sheet}' not found. Available sheets: {', '.join(available_sheets)}"
+                        )
+                    else:
+                        try:
+                            value = get_fund_month_value(excel_data, sheet, fund_name, month)
+                            if value is None:
+                                tool_content = (
+                                    f"Value for fund '{fund_name}' in '{month}' not found."
+                                )
+                            else:
+                                tool_content = json.dumps({"value": value})
+                        except Exception as exc:
+                            tool_content = f"Error retrieving fund value: {exc}"
+                            st.error(f"Error retrieving fund value: {exc}")
 
             # ---------- combined fund metrics ----------------------------- #
             elif name == "calculate_fund_metrics":

--- a/features/llm/chat.py
+++ b/features/llm/chat.py
@@ -80,7 +80,8 @@ def ask_llm(
     # Tell the model explicitly when to call the Excel tools
     sys_prompt += (
         "\n\nIf the user requests data that lives in the uploaded Excel "
-        "workbook, call the `get_excel_data` or `get_fund_series` functions as appropriate. "
+        "workbook, call the `get_excel_data`, `get_fund_series`, or "
+        "`get_fund_month_value` functions as appropriate. "
         "If you receive an error about sheet names, immediately retry with one of the "
         "available sheet names mentioned in the error message. Do not give up after "
         "the first error - always attempt to use the correct sheet names."

--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -188,6 +188,25 @@ FUND_SERIES_TOOL_SCHEMA = {
     },
 }
 
+FUND_MONTH_VALUE_TOOL_SCHEMA = {
+    "name": "get_fund_month_value",
+    "description": (
+        "Return the numeric value for a fund on a specific month in the given Excel sheet."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "sheet": {"type": "string"},
+            "fund_name": {"type": "string"},
+            "month": {
+                "type": "string",
+                "description": "Month to retrieve, e.g. 'Dec 2024'",
+            },
+        },
+        "required": ["sheet", "fund_name", "month"],
+    },
+}
+
 FUND_METRICS_TOOL_SCHEMA = {
     "name": "calculate_fund_metrics",
     "description": (
@@ -253,6 +272,7 @@ TOOLS = [
     {"type": "function", "function": DRAWDOWN_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": EXCEL_TOOL_SCHEMA},      # ← NEW
     {"type": "function", "function": FUND_SERIES_TOOL_SCHEMA},  # ← NEW
+    {"type": "function", "function": FUND_MONTH_VALUE_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_METRICS_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": PORTFOLIO_EXCEL_TOOL_SCHEMA},  # ← NEW
     ]


### PR DESCRIPTION
## Summary
- support retrieving a single month's value for a fund
- expose new `get_fund_month_value` function to the LLM
- wire tool usage into Streamlit app and chat instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd2596d3083248dad722e8769befe