### PR TITLE
Fix Excel loader arrow compatibility

### DIFF
--- a/features/excel/loader.py
+++ b/features/excel/loader.py
@@ -46,6 +46,11 @@ def load_excel(file):
             if pd.api.types.is_datetime64_any_dtype(df[col]):
                 df[col] = df[col].dt.strftime("%d-%b-%Y")
 
+        # Ensure object columns are cast to plain strings for Arrow
+        obj_cols = df.select_dtypes(include="object").columns
+        for obj in obj_cols:
+            df[obj] = df[obj].astype(str)
+
         result[sheet] = df
     
     return result


### PR DESCRIPTION
## Summary
- ensure mixed object columns convert to string before Arrow serialization

## Testing
- `python -m py_compile features/excel/loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6850fecd29688324a5b71ee1e5a13e7a