### PR TITLE
Enable LLM to list Excel sheet names

### DIFF
--- a/appp.py
+++ b/appp.py
@@ -382,7 +382,13 @@ if user_input:
                         tool_content = f"Sheet '{sheet}' not found."
                     else:
                         tool_content = df.head(rows).to_json(orient="records")
-
+            # ---------- list excel sheets ------------------------------ #
+            elif name == "list_excel_sheets":
+                excel_data = st.session_state.get("excel_data")
+                if not excel_data:
+                    tool_content = "No Excel data available. Please upload an Excel file first."
+                else:
+                    tool_content = json.dumps({"sheets": list(excel_data.keys())})
             # ---------- fund series from excel ----------------------------- #
             elif name == "get_fund_series":
                 excel_data = st.session_state.get("excel_data")

--- a/features/excel/loader.py
+++ b/features/excel/loader.py
@@ -225,3 +225,8 @@ def get_fund_rankings(
             return res
 
     return None
+
+def list_sheets(excel_data: dict[str, pd.DataFrame]) -> list[str]:
+    """Return all sheet names present in the uploaded workbook."""
+    return list(excel_data)
+

--- a/features/llm/chat.py
+++ b/features/llm/chat.py
@@ -81,7 +81,7 @@ def ask_llm(
     sys_prompt += (
         "\n\nIf the user requests data that lives in the uploaded Excel "
         "workbook, call the `get_excel_data`, `get_fund_rankings`, "
-        "`get_fund_series`, or `get_fund_month_value` functions as appropriate. "
+        "`list_excel_sheets`, `get_fund_series`, or `get_fund_month_value` functions as appropriate. "
         "`get_fund_rankings` can search all sheets if no sheet name is given. "
         "If you receive an error about sheet names, immediately retry with one of the "
         "available sheet names mentioned in the error message. Do not give up after "

--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -169,6 +169,12 @@ EXCEL_TOOL_SCHEMA = {
     },
 }
 
+LIST_SHEETS_TOOL_SCHEMA = {
+    "name": "list_excel_sheets",
+    "description": "Return the available sheet names from the uploaded Excel workbook.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
 FUND_SERIES_TOOL_SCHEMA = {
     "name": "get_fund_series",
     "description": (
@@ -288,6 +294,7 @@ TOOLS = [
     {"type": "function", "function": FX_RATE_TOOL_SCHEMA},
     {"type": "function", "function": DRAWDOWN_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": EXCEL_TOOL_SCHEMA},      # ← NEW
+    {"type": "function", "function": LIST_SHEETS_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_SERIES_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_MONTH_VALUE_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_RANKINGS_TOOL_SCHEMA},  # ← NEW


### PR DESCRIPTION
## Summary
- add `list_sheets` helper for Excel workbooks
- expose new `list_excel_sheets` tool to the LLM
- update system prompt to mention the new tool
- handle `list_excel_sheets` calls in the Streamlit app
- include new helper in imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851196d01b88324a6fef49929fb9c5a