### PR TITLE
Ensure full ticker used for fund ranking searches

### DIFF
--- a/features/llm/prompts.py
+++ b/features/llm/prompts.py
@@ -17,7 +17,7 @@ SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered portfolio analysis as
     * For portfolio statistics (returns, volatility, draw-down), call `calculate_portfolio_metrics` or `calculate_max_drawdown` as appropriate.
     * To summarise yearly performance, call `calculate_yearly_performance`.
     * When spreadsheet data is requested, call `get_excel_data` with the sheet name and desired number of rows.
-    * To retrieve fund rankings, call `get_fund_rankings` with the ticker. Include the sheet name only if you want to restrict the search.
+    * To retrieve fund rankings, call `get_fund_rankings` with the ticker. **Always pass the ticker exactly as the user provides it, including any spaces or suffixes like "US Equity".** Include the sheet name only if you want to restrict the search.
     * When calculations require converting between currencies (for example when computing combined NAV or AUM), call `get_fx_rate` to obtain the latest foreign exchange rates before performing the conversion.
     * Ensure any function output is clearly explained and linked back to the user's question
 
@@ -53,7 +53,8 @@ SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered portfolio analysis as
     * For ranking data, call `get_fund_rankings` without a sheet name if you're unsure which sheet contains the ticker. This function will automatically scan all sheets in the rankings workbook.
 
 9. **Provide Fund Ranking Data from Excel Data:**
-    * If the user request to find out the ranking of a fund, search the ticker provided in colunm B of the Excel data
+    * If the user request to find out the ranking of a fund, search the ticker provided in column B of the Excel data.
+    * Always search using the **full ticker exactly as stated by the user** (e.g., "QQQ US Equity" rather than just "QQQ").
     * To answer questions about fund rankings, use `get_fund_rankings` with the ticker (and optionally a sheet). The ticker lives in column B while the ranking columns are R, V, Y, AB, AM, AO, AQ, and AS.
     * Return the user with the ranking and the following description : Column V – rank for the –1 YR Return, Column Y – rank for the –2 & 3 YR Return, Column AB – rank for the –4 & 5 YR Return,
     Column AM – rank for Maximum Drawdown %, Column AO – rank for the Sharpe Ratio, Column AQ – rank for the Sortino Ratio, Column AS – rank for the Treynor Measure

--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -212,7 +212,7 @@ FUND_RANKINGS_TOOL_SCHEMA = {
     "name": "get_fund_rankings",
     "description": (
         "Search column B across the uploaded rankings workbook for a ticker "
-        "and return ranking values from columns R, V, Y, AB, AM, AO, AQ and AS. "
+        "and return ranking values from columns R, V, Y, AB, AM, AO, AQ and AS. Always use the full ticker exactly as provided by the user, including spaces or suffixes such as 'US Equity'. "
         "An optional sheet name can be provided to narrow the search."
     ),
     "parameters": {


### PR DESCRIPTION
## Summary
- clarify in the system prompt that `get_fund_rankings` must use the entire ticker string
- emphasize full ticker searches when retrieving fund ranking data
- update the tool description for `get_fund_rankings` to say the full ticker must be used

## Testing
- `python3 -m py_compile features/llm/prompts.py features/llm/tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68514667bcf48324ada462ce91cdd9d2