### PR TITLE
Remove unwanted return fields

### DIFF
--- a/appp.py
+++ b/appp.py
@@ -29,7 +29,8 @@ from features.excel.loader import (
     load_excel,
     get_fund_series,
     get_fund_month_value,
-    get_fund_rankings,    
+    get_fund_rankings,
+    get_fund_details,
 )
 
 # --------------------------------------------------------------------------- #
@@ -702,6 +703,24 @@ if user_input:
                             tool_content = json.dumps(rankings)
                     except Exception as exc:
                         tool_content = f"Error retrieving fund rankings: {exc}"
+                        st.error(tool_content)
+
+            # ---------- fund details lookup --------------------------- #
+            elif name == "get_fund_details":
+                ranking_data = st.session_state.get("ranking_excel_data")
+                if not ranking_data:
+                    tool_content = "No rankings Excel available. Please upload a rankings file first."
+                else:
+                    ticker = args.get("ticker")
+                    sheet = args.get("sheet")
+                    try:
+                        details = get_fund_details(ranking_data, ticker, sheet)
+                        if details is None:
+                            tool_content = f"Ticker '{ticker}' not found in the rankings workbook."
+                        else:
+                            tool_content = json.dumps(details)
+                    except Exception as exc:
+                        tool_content = f"Error retrieving fund details: {exc}"
                         st.error(tool_content)
 
             # ---------- combined fund metrics ----------------------------- #

--- a/features/excel/loader.py
+++ b/features/excel/loader.py
@@ -232,6 +232,90 @@ def get_fund_rankings(
 
     return results or None
 
+
+def get_fund_details(
+    excel_data: dict[str, pd.DataFrame],
+    ticker: str,
+    sheet: str | None = None,
+) -> dict[str, dict[str, str | float]] | None:
+    """Return detailed information for ``ticker`` from the workbook.
+
+    The search is case-insensitive against column **B**. If the ticker is
+    found, values from various columns (fund type, currency, short-term
+    returns, negative-year returns, and fees) are extracted. Long-term and
+    prior calendar year returns are omitted. The result is a dictionary keyed
+    by sheet name for each sheet containing the ticker. Sharpe Ratio,
+    Sortino Ratio and Treynor Measure values are returned in percentage
+    form.
+    """
+
+    def _clean(val):
+        if pd.isna(val):
+            return None
+        txt = str(val).replace("%", "").replace(",", "").strip()
+        try:
+            return float(txt)
+        except ValueError:
+            return str(val).strip()
+
+    def _search(df: pd.DataFrame) -> dict[str, str | float] | None:
+        tickers = df.iloc[:, 1].astype(str).str.strip().str.lower()
+        mask = tickers == ticker.strip().lower()
+        if not mask.any():
+            return None
+        row = df.loc[mask].iloc[0]
+
+        col_map = {
+            "fund_type": 3,           # D
+            "long_name": 7,           # H
+            "currency": 8,            # I
+            "mtd_total_return_pct": 11,  # L
+            "qtd_total_return_pct": 12,  # M
+            "ytd_total_return_pct": 13,  # N
+            "return_neg_1yr": 20,       # U
+            "return_neg_2_3yr": 23,     # X
+            "return_neg_4_5yr": 26,     # AA
+            "downside_risk_ann": 34,    # AI
+            "return_volatility": 35,    # AJ
+            "maximum_total_return": 36,  # AK
+            "maximum_drawdown_pct": 37,  # AL
+            "return_sharpe_ratio": 39,  # AN
+            "sortino_ratio": 41,       # AP
+            "treynor_measure": 43,     # AR
+            "fund_manager_fee": 52,    # BA
+            "expense_ratio": 53,       # BB
+        }
+
+        result = {k: _clean(row.iloc[idx]) if idx < len(row) else None for k, idx in col_map.items()}
+
+        pct_keys = ["return_sharpe_ratio", "sortino_ratio", "treynor_measure"]
+        for key in pct_keys:
+            val = result.get(key)
+            if isinstance(val, (int, float)):
+                result[key] = round(val * 100, 4)
+
+        return result
+
+    results: dict[str, dict[str, str | float]] = {}
+
+    searched: set[str] = set()
+    if sheet:
+        df = excel_data.get(sheet)
+        if df is not None:
+            searched.add(sheet)
+            res = _search(df)
+            if res is not None:
+                results[sheet] = res
+
+    for name, df in excel_data.items():
+        if name in searched:
+            continue
+        res = _search(df)
+        if res is not None:
+            results[name] = res
+
+    return results or None
+
 def list_sheets(excel_data: dict[str, pd.DataFrame]) -> list[str]:
     """Return all sheet names present in the uploaded workbook."""
     return list(excel_data)

--- a/features/llm/chat.py
+++ b/features/llm/chat.py
@@ -80,7 +80,7 @@ def ask_llm(
     sys_prompt += (
         "\n\nIf the user requests data that lives in the uploaded Excel "
         "workbook, call the `get_excel_data`, `get_fund_rankings`, "
-        "`list_excel_sheets`, `get_fund_series`, or `get_fund_month_value` functions as appropriate. "
+        "`get_fund_details`, `list_excel_sheets`, `get_fund_series`, or `get_fund_month_value` functions as appropriate. "
         "`get_fund_rankings` returns a dictionary keyed by sheet name and searches all sheets if no sheet name is given. "
         "Do not assume a sheet called 'Main Funds'. If you are unsure which sheet contains the data, omit the sheet parameter so the function searches the entire workbook. "
         "If you receive an error about sheet names, immediately retry with one of the "

--- a/features/llm/prompts.py
+++ b/features/llm/prompts.py
@@ -58,7 +58,11 @@ SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered portfolio analysis as
     Column AM – rank for Maximum Drawdown %, Column AO – rank for the Sharpe Ratio, Column AQ – rank for the Sortino Ratio, Column AS – rank for the Treynor Measure
     * Tell the user which sheet the ranking was found in, e.g., "The fund ranking for `TICKER` was found in the specific Excel sheet `Sheet_Name`."
 
-10. **Reference Document Handling:**
+10. **Retrieve Detailed Fund Data from Excel:**
+    * Use `get_fund_details` with the ticker to pull columns like fund type, currency, recent returns and fees. Search column B across all sheets unless a sheet name is provided.
+    * Present the Sharpe Ratio, Sortino Ratio and Treynor Measure returned by this function as percentages (e.g., `15.4%`).
+
+11. **Reference Document Handling:**
     * You have access to a set of reference documents such as pricing sheets, fund offering memorandums, institutional communications, and platform-specific guidelines.
     * When answering questions based on these documents:
         - **Do not merge or blend information** across unrelated documents. For example, retrocession pricing from one institution must NOT be mix5ed with non-retrocession data from another.
@@ -93,7 +97,7 @@ SYSTEM_PROMPT_CORE = """You are "PortfoBot," an AI-powered portfolio analysis as
     * Always provide the fullest and most precise details available.
     * **Avoid making educated guesses or interpretations. Only present data that is explicitly available in the reference material.**
 
-11. **Source Tracking and Consistency:**
+12. **Source Tracking and Consistency:**
     * You MUST always mention the source document filename when referencing information, e.g., “According to `Retrocession_Pricing_ABC.pdf`...”
     * When comparisons are requested, or when you are giving the same type of information across various groups, present differences clearly in a structured format, for example:
         ```

--- a/features/llm/tools.py
+++ b/features/llm/tools.py
@@ -233,6 +233,23 @@ FUND_RANKINGS_TOOL_SCHEMA = {
     },
 }
 
+FUND_DETAILS_TOOL_SCHEMA = {
+    "name": "get_fund_details",
+    "description": (
+        "Look up a ticker in column B across the uploaded workbook and return "
+        "detailed columns like fund type, currency, recent returns and fees. "
+        "You may specify a sheet name to narrow the search."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "ticker": {"type": "string"},
+            "sheet": {"type": "string"},
+        },
+        "required": ["ticker"],
+    },
+}
+
 FUND_METRICS_TOOL_SCHEMA = {
     "name": "calculate_fund_metrics",
     "description": (
@@ -300,6 +317,7 @@ TOOLS = [
     {"type": "function", "function": FUND_SERIES_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_MONTH_VALUE_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_RANKINGS_TOOL_SCHEMA},  # ← NEW
+    {"type": "function", "function": FUND_DETAILS_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": FUND_METRICS_TOOL_SCHEMA},  # ← NEW
     {"type": "function", "function": PORTFOLIO_EXCEL_TOOL_SCHEMA},  # ← NEW
     ]


### PR DESCRIPTION
## Summary
- omit long-term and calendar-year return columns from `get_fund_details`
- clarify docstring to reflect short-term focus

## Testing
- `python -m py_compile features/excel/loader.py features/llm/tools.py features/llm/chat.py appp.py`


------
https://chatgpt.com/codex/tasks/task_e_68590fbe077c83248e33a370901094cc